### PR TITLE
Add gzip compression to Express server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+__MACOSX
+.DS_STORE

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A module for displaying the works of a selected cast/crew member.
 1. Clone this repo to your local machine.
 2. In the root directory of this project, run `docker-compose up --build`.
 
-Note: If updated version of this repo has been pulled after building, run `docker image rm castandcrew:latest` before re-building.
+Note: Run `docker image rm castandcrew:latest` before re-building to remove any duplicate images.
 
 ### Seeding the database
   1. `docker exec -it castandcrew /bin/bash`

--- a/server/index.js
+++ b/server/index.js
@@ -3,6 +3,17 @@ const db = require('../database/index.js');
 const app = express();
 const PORT = 3000;
 
+app.use((req, res, next) => {
+  res.set('Cache-Control', 'public, max-age=31557600');
+  next();
+});
+
+app.use('*.js', (req, res, next) => {
+  req.url = req.url + '.gz';
+  res.set('Content-Encoding', 'gzip');
+  next();
+});
+
 app.use(express.static('./client/dist'));
 app.use(express.json());
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const SRC_DIR = path.join(__dirname, '/client/src');
 const DIST_DIR = path.join(__dirname, '/client/dist');
+const CompressionPlugin = require('compression-webpack-plugin');
 
 module.exports = {
   entry: `${SRC_DIR}/index.js`,
@@ -19,5 +20,16 @@ module.exports = {
         }
       }
     ]
-  }
+  },
+  plugins: [
+    new CompressionPlugin({
+      filename: '[path].gz[query]',
+      algorithm: 'gzip',
+      test: /\.(js|css|html|svg)$/,
+      compressionOptions: { level: 9 },
+      threshold: 0,
+      minRatio: 0.8,
+      deleteOriginalAssets: false,
+    }),
+  ]
 };


### PR DESCRIPTION
In this PR:

- Maintenance on README and .dockerignore
- Webpack and Express configuration for transpiling and serving gzipped files